### PR TITLE
feat(block): 支持正则表达式屏蔽

### DIFF
--- a/app/src/main/assets/litepal.xml
+++ b/app/src/main/assets/litepal.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <litepal>
     <dbname value="tblite" />
-    <version value="37" />
+    <version value="38" />
     <list>
         <mapping class="com.huanchengfly.tieba.post.models.database.Account" />
         <mapping class="com.huanchengfly.tieba.post.models.database.Draft" />

--- a/app/src/main/java/com/huanchengfly/tieba/post/models/database/Block.kt
+++ b/app/src/main/java/com/huanchengfly/tieba/post/models/database/Block.kt
@@ -9,6 +9,7 @@ data class Block @JvmOverloads constructor(
     val keywords: String? = null,
     val username: String? = null,
     val uid: String? = null,
+    val isRegex: Boolean = false // 标记是否为正则表达式
 ) : LitePalSupport() {
     val id: Long = 0L
     companion object {

--- a/app/src/main/java/com/huanchengfly/tieba/post/ui/page/settings/block/blocklist/BlockListPage.kt
+++ b/app/src/main/java/com/huanchengfly/tieba/post/ui/page/settings/block/blocklist/BlockListPage.kt
@@ -1,6 +1,7 @@
 package com.huanchengfly.tieba.post.ui.page.settings.block.blocklist
 
 import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -8,6 +9,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -15,6 +17,8 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Checkbox
 import androidx.compose.material.DropdownMenuItem
 import androidx.compose.material.Icon
 import androidx.compose.material.MaterialTheme
@@ -77,14 +81,17 @@ fun BlockListPage(
 ) {
     var addBlockCategory by remember { mutableStateOf(Block.CATEGORY_BLACK_LIST) }
     val dialogState = rememberDialogState()
+    var isRegex by remember { mutableStateOf(false) } // 记录是否为正则
     PromptDialog(
         onConfirm = {
             viewModel.send(
                 BlockListUiIntent.Add(
                     category = addBlockCategory,
-                    keywords = it.split(" ")
+                    keywords = it.split(" "),
+                    isRegex = isRegex // 传递正则状态
                 )
             )
+            isRegex = false // 重置
         },
         dialogState = dialogState,
         title = {
@@ -94,7 +101,17 @@ fun BlockListPage(
             )
         }
     ) {
-        Text(text = stringResource(id = R.string.tip_add_block))
+        Column {
+            Text(text = stringResource(id = R.string.tip_add_block))
+            Spacer(modifier = Modifier.height(8.dp))
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Checkbox(
+                    checked = isRegex,
+                    onCheckedChange = { isRegex = it }
+                )
+                Text(text = "作为正则表达式")
+            }
+        }
     }
 
     val context = LocalContext.current
@@ -213,9 +230,9 @@ fun BlockListPage(
             }
         }
     ) { paddingValues ->
-        val snackbarHostState = LocalSnackbarHostState.current
+        val snackBarHostState = LocalSnackbarHostState.current
         viewModel.onEvent<BlockListUiEvent.Success> {
-            snackbarHostState.showSnackbar(
+            snackBarHostState.showSnackbar(
                 when (it) {
                     is BlockListUiEvent.Success.Add -> context.getString(R.string.toast_add_success)
                     is BlockListUiEvent.Success.Delete -> context.getString(R.string.toast_delete_success)
@@ -304,7 +321,11 @@ private fun BlockItem(
                 id = R.string.block_type_user
             ) else stringResource(
                 id = R.string.block_type_keywords
-            )
+            ),
+            tint = if (item.isRegex)
+                MaterialTheme.colors.secondary
+            else
+                MaterialTheme.colors.onSurface
         )
         Spacer(modifier = Modifier.width(16.dp))
         Column(
@@ -328,10 +349,30 @@ private fun BlockItem(
                             object : TypeToken<List<String>>() {}.type
                         )
                 }.getOrDefault(emptyList())
-                Text(
-                    text = keywordsList.joinToString(" "),
-                    style = MaterialTheme.typography.subtitle1
-                )
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Text(
+                        text = keywordsList.joinToString(" "),
+                        style = MaterialTheme.typography.subtitle1,
+                        color = if (item.isRegex)
+                            MaterialTheme.colors.secondary
+                        else
+                            MaterialTheme.colors.onSurface
+                    )
+                    if (item.isRegex) {
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Text(
+                            text = "正则",
+                            color = MaterialTheme.colors.secondary,
+                            fontSize = 12.sp,
+                            modifier = Modifier
+                                .background(
+                                    color = MaterialTheme.colors.secondary.copy(alpha = 0.13f),
+                                    shape = RoundedCornerShape(8.dp)
+                                )
+                                .padding(horizontal = 8.dp, vertical = 2.dp)
+                        )
+                    }
+                }
             }
         }
     }

--- a/app/src/main/java/com/huanchengfly/tieba/post/ui/page/settings/block/blocklist/BlockListPage.kt
+++ b/app/src/main/java/com/huanchengfly/tieba/post/ui/page/settings/block/blocklist/BlockListPage.kt
@@ -1,10 +1,13 @@
 package com.huanchengfly.tieba.post.ui.page.settings.block.blocklist
 
+import android.widget.Toast
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -39,10 +42,13 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.google.accompanist.placeholder.material.placeholder
@@ -87,7 +93,7 @@ fun BlockListPage(
             viewModel.send(
                 BlockListUiIntent.Add(
                     category = addBlockCategory,
-                    keywords = it.split(" "),
+                    keywords =  if (isRegex) listOf(it) else it.split(" "), // 避免正则中的空格导致正则失效
                     isRegex = isRegex // 传递正则状态
                 )
             )
@@ -264,20 +270,38 @@ fun BlockListPage(
                 },
                 modifier = Modifier.fillMaxSize()
             ) {
+                val clipboardManager = LocalClipboardManager.current
+                val context = LocalContext.current
                 MyLazyColumn(Modifier.fillMaxSize()) {
-                    items(items, key = { it.id }) {
+                    items(items, key = { it.id }) { item ->
                         LongClickMenu(menuContent = {
+
+                            // 复制功能
+                            DropdownMenuItem(onClick = {
+                                val keywordsList: List<String> = GsonUtil.getGson().fromJson(
+                                    item.keywords ?: "[]",
+                                    object : TypeToken<List<String>>() {}.type
+                                )
+                                val merged = if (item.isRegex) {
+                                    keywordsList.joinToString(separator = "")
+                                } else {
+                                    keywordsList.joinToString(separator = " ")
+                                }
+
+                                clipboardManager.setText(AnnotatedString(merged))
+                                Toast.makeText(context, R.string.toast_copy_success, Toast.LENGTH_SHORT).show()
+                            }) {
+                                Text(text = stringResource(id = R.string.title_copy))
+                            }
                             DropdownMenuItem(onClick = {
                                 viewModel.send(
-                                    BlockListUiIntent.Delete(
-                                        it.id
-                                    )
+                                    BlockListUiIntent.Delete(item.id)
                                 )
                             }) {
                                 Text(text = stringResource(id = R.string.title_delete))
                             }
                         }) {
-                            BlockItem(item = it)
+                            BlockItem(item = item)
                         }
                     }
                 }
@@ -305,6 +329,7 @@ private fun BlockItemPlaceholder() {
     }
 }
 
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 private fun BlockItem(
     item: Block,
@@ -349,17 +374,22 @@ private fun BlockItem(
                             object : TypeToken<List<String>>() {}.type
                         )
                 }.getOrDefault(emptyList())
-                Row(verticalAlignment = Alignment.CenterVertically) {
+                FlowRow(
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalArrangement = Arrangement.spacedBy(0.dp),
+                    modifier = Modifier.fillMaxWidth()
+                ) {
                     Text(
                         text = keywordsList.joinToString(" "),
                         style = MaterialTheme.typography.subtitle1,
                         color = if (item.isRegex)
                             MaterialTheme.colors.secondary
                         else
-                            MaterialTheme.colors.onSurface
+                            MaterialTheme.colors.onSurface,
+                        maxLines = Int.MAX_VALUE, // 支持多行
+                        overflow = TextOverflow.Visible
                     )
                     if (item.isRegex) {
-                        Spacer(modifier = Modifier.width(8.dp))
                         Text(
                             text = "正则",
                             color = MaterialTheme.colors.secondary,

--- a/app/src/main/java/com/huanchengfly/tieba/post/ui/page/settings/block/blocklist/BlockListViewModel.kt
+++ b/app/src/main/java/com/huanchengfly/tieba/post/ui/page/settings/block/blocklist/BlockListViewModel.kt
@@ -51,7 +51,10 @@ class BlockListViewModel :
         private fun BlockListUiIntent.Add.producePartialChange(): Flow<BlockListPartialChange.Add> =
             flow<BlockListPartialChange.Add> {
                 val block = Block(
-                    category = category, type = Block.TYPE_KEYWORD, keywords = keywords.toJson()
+                    category = category,
+                    type = Block.TYPE_KEYWORD,
+                    keywords = keywords.toJson(),
+                    isRegex = isRegex
                 )
                 BlockManager.addBlock(block)
                 emit(BlockListPartialChange.Add.Success(block))
@@ -70,7 +73,8 @@ sealed interface BlockListUiIntent : UiIntent {
 
     data class Add(
         val category: Int,
-        val keywords: List<String>
+        val keywords: List<String>,
+        val isRegex: Boolean = false
     ) : BlockListUiIntent
 
     data class Delete(

--- a/app/src/main/java/com/huanchengfly/tieba/post/utils/BlockManager.kt
+++ b/app/src/main/java/com/huanchengfly/tieba/post/utils/BlockManager.kt
@@ -11,6 +11,7 @@ import com.huanchengfly.tieba.post.models.database.Block.Companion.getKeywords
 import org.litepal.LitePal
 import org.litepal.extension.delete
 import org.litepal.extension.findAllAsync
+import java.util.regex.Pattern
 
 object BlockManager {
     private val blockList: MutableList<Block> = mutableListOf()
@@ -49,13 +50,34 @@ object BlockManager {
     }
 
     fun shouldBlock(content: String): Boolean {
-        return blackList.any { block ->
-            block.type == Block.TYPE_KEYWORD
-                    && block.getKeywords().all { content.contains(it) }
-        } && whiteList.none { block ->
-            block.type == Block.TYPE_KEYWORD
-                    && block.getKeywords().all { content.contains(it) }
+        // 支持正则表达式的屏蔽判断
+        val isBlack = blackList.any { block ->
+            block.type == Block.TYPE_KEYWORD && block.getKeywords().all { keyword ->
+                if (block.isRegex) {
+                    try {
+                        Pattern.compile(keyword).matcher(content).find()
+                    } catch (e: Exception) {
+                        false // 如果正则表达式非法则忽略
+                    }
+                } else {
+                    content.contains(keyword)
+                }
+            }
         }
+        val isWhite = whiteList.any { block ->
+            block.type == Block.TYPE_KEYWORD && block.getKeywords().all { keyword ->
+                if (block.isRegex) {
+                    try {
+                        Pattern.compile(keyword).matcher(content).find()
+                    } catch (e: Exception) {
+                        false
+                    }
+                } else {
+                    content.contains(keyword)
+                }
+            }
+        }
+        return isBlack && !isWhite
     }
 
     fun shouldBlock(userId: Long = 0L, userName: String? = null): Boolean {

--- a/app/src/main/java/com/huanchengfly/tieba/post/utils/BlockManager.kt
+++ b/app/src/main/java/com/huanchengfly/tieba/post/utils/BlockManager.kt
@@ -51,25 +51,12 @@ object BlockManager {
 
     fun shouldBlock(content: String): Boolean {
         // 支持正则表达式的屏蔽判断
-        val isBlack = blackList.any { block ->
-            block.type == Block.TYPE_KEYWORD && block.getKeywords().all { keyword ->
-                if (block.isRegex) {
-                    try {
-                        Pattern.compile(keyword).matcher(content).find()
-                    } catch (e: Exception) {
-                        false // 如果正则表达式非法则忽略
-                    }
-                } else {
-                    content.contains(keyword)
-                }
-            }
-        }
         val isWhite = whiteList.any { block ->
             block.type == Block.TYPE_KEYWORD && block.getKeywords().all { keyword ->
                 if (block.isRegex) {
                     try {
                         Pattern.compile(keyword).matcher(content).find()
-                    } catch (e: Exception) {
+                    } catch (_: Exception) {
                         false
                     }
                 } else {
@@ -77,17 +64,42 @@ object BlockManager {
                 }
             }
         }
-        return isBlack && !isWhite
+        if (isWhite)
+            return false
+        val isBlack = blackList.any { block ->
+            block.type == Block.TYPE_KEYWORD && block.getKeywords().all { keyword ->
+                if (block.isRegex) {
+                    try {
+                        Pattern.compile(keyword).matcher(content).find()
+                    } catch (_: Exception) {
+                        false // 如果正则表达式非法则忽略
+                    }
+                } else {
+                    content.contains(keyword)
+                }
+            }
+        }
+        return isBlack
     }
 
     fun shouldBlock(userId: Long = 0L, userName: String? = null): Boolean {
-        return blackList.any { block ->
-            block.type == Block.TYPE_USER
-                    && (block.uid == userId.toString() || block.username == userName)
-        } && whiteList.none { block ->
+        val isWhite = whiteList.any { block ->
+            if (block.isRegex) {
+                return false
+            }
             block.type == Block.TYPE_USER
                     && (block.uid == userId.toString() || block.username == userName)
         }
+        if (isWhite)
+            return false
+        val isBlack = blackList.any { block ->
+            if (block.isRegex) {
+                return false
+            }
+            block.type == Block.TYPE_USER
+                    && (block.uid == userId.toString() || block.username == userName)
+        }
+        return isBlack
     }
 
     fun ThreadInfo.shouldBlock(): Boolean =

--- a/app/src/main/java/com/huanchengfly/tieba/post/utils/BlockManager.kt
+++ b/app/src/main/java/com/huanchengfly/tieba/post/utils/BlockManager.kt
@@ -52,7 +52,7 @@ object BlockManager {
     fun shouldBlock(content: String): Boolean {
         // 支持正则表达式的屏蔽判断
         val isWhite = whiteList.any { block ->
-            block.type == Block.TYPE_KEYWORD && block.getKeywords().all { keyword ->
+            block.type == Block.TYPE_KEYWORD && block.getKeywords().any { keyword ->
                 if (block.isRegex) {
                     try {
                         Pattern.compile(keyword).matcher(content).find()
@@ -67,7 +67,7 @@ object BlockManager {
         if (isWhite)
             return false
         val isBlack = blackList.any { block ->
-            block.type == Block.TYPE_KEYWORD && block.getKeywords().all { keyword ->
+            block.type == Block.TYPE_KEYWORD && block.getKeywords().any { keyword ->
                 if (block.isRegex) {
                     try {
                         Pattern.compile(keyword).matcher(content).find()
@@ -84,20 +84,16 @@ object BlockManager {
 
     fun shouldBlock(userId: Long = 0L, userName: String? = null): Boolean {
         val isWhite = whiteList.any { block ->
-            if (block.isRegex) {
-                return false
-            }
-            block.type == Block.TYPE_USER
-                    && (block.uid == userId.toString() || block.username == userName)
+            !block.isRegex &&
+                    block.type == Block.TYPE_USER &&
+                    (block.uid == userId.toString() || block.username == userName)
         }
-        if (isWhite)
-            return false
+        if (isWhite) return false
+
         val isBlack = blackList.any { block ->
-            if (block.isRegex) {
-                return false
-            }
-            block.type == Block.TYPE_USER
-                    && (block.uid == userId.toString() || block.username == userName)
+            !block.isRegex &&
+                    block.type == Block.TYPE_USER &&
+                    (block.uid == userId.toString() || block.username == userName)
         }
         return isBlack
     }


### PR DESCRIPTION
- 在 Block模型中添加 isRegex 字段，用于标记是否为正则表达式
- 在 BlockListPage 中增加正则表达式选项，用户可以选择是否作为正则表达式添加关键词
- 修改 BlockListViewModel 和 BlockManager 以支持正则表达式的处理
- 更新数据库版本号

![image](https://github.com/user-attachments/assets/04fd63f4-7a3f-4665-9026-4bf333e130ac)
