### PR TITLE
feat: 发帖支持标题输入并优化首页空状态

### DIFF
--- a/app/src/main/java/com/huanchengfly/tieba/post/ui/page/main/home/HomePage.kt
+++ b/app/src/main/java/com/huanchengfly/tieba/post/ui/page/main/home/HomePage.kt
@@ -453,8 +453,15 @@ fun HomePage(
         prop1 = HomeUiState::error,
         initial = null
     )
+    val hasLoaded by viewModel.uiState.collectPartialAsState(
+        prop1 = HomeUiState::hasLoaded,
+        initial = false
+    )
     val isLoggedIn = remember(account) { account != null }
     val isEmpty by remember { derivedStateOf { forums.isEmpty() } }
+    val showEmptyState by remember {
+        derivedStateOf { isEmpty && (!isLoggedIn || hasLoaded) }
+    }
     val hasTopForum by remember { derivedStateOf { topForums.isNotEmpty() } }
     val showHistoryForum by remember { derivedStateOf { context.appPreferences.homePageShowHistoryForum && historyForums.isNotEmpty() } }
     var listSingle by remember { mutableStateOf(context.appPreferences.listSingle) }
@@ -531,7 +538,7 @@ fun HomePage(
                     navigator.navigate(SearchPageDestination)
                 }
                 StateScreen(
-                    isEmpty = isEmpty,
+                    isEmpty = showEmptyState,
                     isError = isError,
                     isLoading = isLoading,
                     modifier = Modifier

--- a/app/src/main/java/com/huanchengfly/tieba/post/ui/page/main/home/HomeViewModel.kt
+++ b/app/src/main/java/com/huanchengfly/tieba/post/ui/page/main/home/HomeViewModel.kt
@@ -178,13 +178,14 @@ sealed interface HomePartialChange : PartialChange<HomeUiState> {
             when (this) {
                 is Success -> oldState.copy(
                     isLoading = false,
+                    hasLoaded = true,
                     forums = forums.toImmutableList(),
                     topForums = topForums.toImmutableList(),
                     historyForums = historyForums.toImmutableList(),
                     error = null
                 )
 
-                is Failure -> oldState.copy(isLoading = false, error = error)
+                is Failure -> oldState.copy(isLoading = false, hasLoaded = true, error = error)
                 Start -> oldState.copy(isLoading = true)
             }
 
@@ -265,6 +266,7 @@ sealed interface HomePartialChange : PartialChange<HomeUiState> {
 @Immutable
 data class HomeUiState(
     val isLoading: Boolean = false,
+    val hasLoaded: Boolean = false,
     val forums: ImmutableList<Forum> = persistentListOf(),
     val topForums: ImmutableList<Forum> = persistentListOf(),
     val historyForums: ImmutableList<History> = persistentListOf(),

--- a/app/src/main/java/com/huanchengfly/tieba/post/ui/page/reply/ReplyPage.kt
+++ b/app/src/main/java/com/huanchengfly/tieba/post/ui/page/reply/ReplyPage.kt
@@ -75,8 +75,11 @@ import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.rememberTextMeasurer
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.core.widget.addTextChangedListener
 import com.github.panpf.sketch.compose.AsyncImage
@@ -100,6 +103,7 @@ import com.huanchengfly.tieba.post.ui.page.reply.ReplyPanelType.IMAGE
 import com.huanchengfly.tieba.post.ui.page.reply.ReplyPanelType.NONE
 import com.huanchengfly.tieba.post.ui.utils.imeNestedScroll
 import com.huanchengfly.tieba.post.ui.widgets.compose.BaseDialog
+import com.huanchengfly.tieba.post.ui.widgets.compose.BaseTextField
 import com.huanchengfly.tieba.post.ui.widgets.compose.Dialog
 import com.huanchengfly.tieba.post.ui.widgets.compose.DialogNegativeButton
 import com.huanchengfly.tieba.post.ui.widgets.compose.DialogPositiveButton
@@ -233,10 +237,12 @@ internal fun ReplyPageContent(
         prop1 = ReplyUiState::replyType,
         initial = NONE
     )
+    val isTopicThread = replyType == ReplyType.TOPIC_THREAD
     //threadId为0时切换为发主题帖
     if (forumId != 0L && threadId == 0L) viewModel.send(ReplyUiIntent.SwitchReplyType(ReplyType.TOPIC_THREAD))
     val keyboardController = LocalSoftwareKeyboardController.current
     var initialText by remember { mutableStateOf("") }
+    var threadTitle by remember { mutableStateOf("") }
     var waitEditTextToSet by remember { mutableStateOf(false) }
     var editTextView by remember { mutableStateOf<UndoableEditText?>(null) }
     fun getText(): String {
@@ -293,6 +299,14 @@ internal fun ReplyPageContent(
             else -> context.getString(R.string.title_reply)
         }
     }
+    LaunchedEffect(replyType, editTextView) {
+        editTextView?.hint = when {
+            replyType == ReplyType.TOPIC_THREAD -> context.getString(R.string.tip_thread_content)
+            subPostId != null && subPostId != 0L && replyUserName != null ->
+                context.getString(R.string.hint_reply, replyUserName)
+            else -> context.getString(R.string.tip_reply)
+        }
+    }
     viewModel.onEvent<ReplyUiEvent.ReplySuccess> {
         if (it.expInc.isEmpty()) {
             context.toastShort(R.string.toast_add_thread_success_default)
@@ -320,6 +334,7 @@ internal fun ReplyPageContent(
                     forumName,
                     threadId,
                     curTbs,
+                    title = threadTitle.takeIf { isTopicThread },
                     postId,
                     subPostId,
                     replyUserId,
@@ -481,6 +496,31 @@ internal fun ReplyPageContent(
             )
         }
         VerticalDivider(modifier = Modifier.padding(horizontal = 16.dp))
+        if (isTopicThread) {
+            BaseTextField(
+                value = threadTitle,
+                onValueChange = { if (it.length <= 31) threadTitle = it },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 8.dp),
+                singleLine = true,
+                textStyle = MaterialTheme.typography.subtitle1.copy(
+                    fontWeight = FontWeight.Bold,
+                    fontSize = 15.sp,
+                ),
+                keyboardOptions = KeyboardOptions(
+                    capitalization = KeyboardCapitalization.Sentences,
+                ),
+                placeholder = {
+                    Text(
+                        text = stringResource(id = R.string.hint_thread_title),
+                        style = MaterialTheme.typography.subtitle1.copy(fontSize = 15.sp),
+                        color = ExtendedTheme.colors.textSecondary,
+                    )
+                },
+            )
+            VerticalDivider(modifier = Modifier.padding(horizontal = 16.dp))
+        }
         Box(
             modifier = Modifier
                 .wrapContentHeight()
@@ -502,8 +542,11 @@ internal fun ReplyPageContent(
                             null
                         ) as UndoableEditText).apply {
                             editTextView = this
-                            if (subPostId != null && subPostId != 0L && replyUserName != null) {
-                                hint = ctx.getString(R.string.hint_reply, replyUserName)
+                            hint = when {
+                                isTopicThread -> ctx.getString(R.string.tip_thread_content)
+                                subPostId != null && subPostId != 0L && replyUserName != null ->
+                                    ctx.getString(R.string.hint_reply, replyUserName)
+                                else -> ctx.getString(R.string.tip_reply)
                             }
                             setOnFocusChangeListener { _, hasFocus ->
                                 if (hasFocus) {
@@ -622,6 +665,7 @@ internal fun ReplyPageContent(
                                     forumName = forumName,
                                     threadId = threadId,
                                     tbs = curTbs,
+                                    title = threadTitle.takeIf { isTopicThread },
                                     postId = postId,
                                     subPostId = subPostId,
                                     replyUserId = replyUserId

--- a/app/src/main/java/com/huanchengfly/tieba/post/ui/page/reply/ReplyViewModel.kt
+++ b/app/src/main/java/com/huanchengfly/tieba/post/ui/page/reply/ReplyViewModel.kt
@@ -110,14 +110,15 @@ class ReplyViewModel @Inject constructor() :
 
         private fun ReplyUiIntent.Send.producePartialChange(): Flow<ReplyPartialChange.Send> {
             if (forumId != 0L && threadId == 0L ) {
+                val threadTitle = title.orEmpty()
                 return AddPostRepository
                     .addThread(
                         content,
                         forumId,
                         forumName,
-                        title = "",//这三个后面再做
+                        title = threadTitle,
                         isHide = 1,
-                        isTitle = 1,
+                        isTitle = if (threadTitle.isBlank()) 1 else 0,
                     )
                     .map<AddThreadBean, ReplyPartialChange.Send> {
                         if (it.tid == null) throw TiebaUnknownException
@@ -222,6 +223,7 @@ sealed interface ReplyUiIntent : UiIntent {
         val forumName: String,
         val threadId: Long,
         val tbs: String,
+        val title: String? = null,
         val postId: Long? = null,
         val subPostId: Long? = null,
         val replyUserId: Long? = null,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -35,6 +35,8 @@
     <string name="title_collect_on">取消收藏</string>
     <string name="title_reply">回复</string>
     <string name="title_thread">发帖</string>
+    <string name="hint_thread_title">输入标题</string>
+    <string name="tip_thread_content">写下正文…</string>
     <string name="tip_reply">评论一番，提高自己的姿势水平…</string>
     <string name="title_account_manage">账号管理</string>
     <string name="title_block_settings">屏蔽设置</string>


### PR DESCRIPTION
## Summary

- 发主题帖时增加标题输入框，标题与正文分离展示；有标题时传 `is_ntitle=0`，标题为空时保持原有无标题帖逻辑
- 修复冷启动首页短暂闪现「这里什么都没有」的问题：首次加载完成前不显示空状态页

## Changes

- `ReplyPage` / `ReplyViewModel`：发帖 UI 与 API 传参
- `strings.xml`：标题、正文提示文案
- `HomePage` / `HomeViewModel`：增加 `hasLoaded` 标记，控制空状态显示时机

## Test plan

- [x] 吧内发帖，填写标题和正文，发送成功
- [x] 帖子详情页标题（粗体）与正文样式区分正常
- [x] 标题留空仍可发帖（无标题帖）
- [x] 冷启动首页不再短暂闪空状态