### PR TITLE
  feat: 支持楼中楼图片显示

### DIFF
--- a/app/src/main/java/com/huanchengfly/tieba/post/api/Enums.kt
+++ b/app/src/main/java/com/huanchengfly/tieba/post/api/Enums.kt
@@ -3,7 +3,8 @@ package com.huanchengfly.tieba.post.api
 enum class ClientVersion(val version: String) {
     TIEBA_V11("11.10.8.6"),
     TIEBA_V12("12.52.1.0"),
-    TIEBA_V12_POST("12.35.1.0");
+    TIEBA_V12_POST("12.35.1.0"),
+    TIEBA_V22("22.10.1.0");
 
     override fun toString(): String {
         return version

--- a/app/src/main/java/com/huanchengfly/tieba/post/api/ProtobufRequest.kt
+++ b/app/src/main/java/com/huanchengfly/tieba/post/api/ProtobufRequest.kt
@@ -73,13 +73,14 @@ fun buildCommonRequest(
     bduss: String? = null,
     stoken: String? = null,
     tbs: String? = null,
+    clientVersionValue: String = clientVersion.version,
 ): CommonRequest = when (clientVersion) {
     ClientVersion.TIEBA_V11 -> {
         CommonRequest(
             BDUSS = bduss ?: AccountUtil.getBduss(),
             _client_id = ClientUtils.clientId ?: RetrofitTiebaApi.randomClientId,
             _client_type = 2,
-            _client_version = clientVersion.version,
+            _client_version = clientVersionValue,
             _os_version = "${Build.VERSION.SDK_INT}",
             _phone_imei = MobileInfoUtil.getIMEI(context),
             _timestamp = System.currentTimeMillis(),
@@ -105,7 +106,7 @@ fun buildCommonRequest(
             BDUSS = AccountUtil.getBduss(),
             _client_id = ClientUtils.clientId ?: RetrofitTiebaApi.randomClientId,
             _client_type = 2,
-            _client_version = clientVersion.version,
+            _client_version = clientVersionValue,
             _os_version = "${Build.VERSION.SDK_INT}",
             _phone_imei = MobileInfoUtil.getIMEI(context),
             _timestamp = System.currentTimeMillis(),
@@ -144,7 +145,7 @@ fun buildCommonRequest(
             start_type = 1,
             stoken = AccountUtil.getSToken(),
             swan_game_ver = "1038000",
-            user_agent = getUserAgent("tieba/${clientVersion.version}"),
+            user_agent = getUserAgent("tieba/$clientVersionValue"),
             z_id = AccountUtil.getAccountInfo { zid }
         )
     }
@@ -154,7 +155,7 @@ fun buildCommonRequest(
             BDUSS = AccountUtil.getBduss(),
             _client_id = ClientUtils.clientId ?: RetrofitTiebaApi.randomClientId,
             _client_type = 2,
-            _client_version = clientVersion.version,
+            _client_version = clientVersionValue,
             _os_version = "${Build.VERSION.SDK_INT}", // TODO
             _phone_imei = MobileInfoUtil.getIMEI(context),
             _timestamp = System.currentTimeMillis(),
@@ -196,7 +197,7 @@ fun buildCommonRequest(
             stoken = AccountUtil.getSToken(),
             swan_game_ver = "1038000",
             tbs = tbs,
-            user_agent = getUserAgent("tieba/${clientVersion.version}"),
+            user_agent = getUserAgent("tieba/$clientVersionValue"),
             z_id = AccountUtil.getAccountInfo { zid }
         )
     }

--- a/app/src/main/java/com/huanchengfly/tieba/post/api/ProtobufRequest.kt
+++ b/app/src/main/java/com/huanchengfly/tieba/post/api/ProtobufRequest.kt
@@ -33,7 +33,7 @@ fun buildProtobufRequestBody(
     return MyMultipartBody.Builder(BOUNDARY)
         .apply {
             setType(MyMultipartBody.FORM)
-            if (clientVersion != ClientVersion.TIEBA_V12 && clientVersion != ClientVersion.TIEBA_V12_POST) {
+            if (clientVersion != ClientVersion.TIEBA_V12 && clientVersion != ClientVersion.TIEBA_V12_POST && clientVersion != ClientVersion.TIEBA_V22) {
                 addFormDataPart(Param.CLIENT_VERSION, clientVersion.version)
             }
             if (needSToken) {
@@ -73,14 +73,13 @@ fun buildCommonRequest(
     bduss: String? = null,
     stoken: String? = null,
     tbs: String? = null,
-    clientVersionValue: String = clientVersion.version,
 ): CommonRequest = when (clientVersion) {
     ClientVersion.TIEBA_V11 -> {
         CommonRequest(
             BDUSS = bduss ?: AccountUtil.getBduss(),
             _client_id = ClientUtils.clientId ?: RetrofitTiebaApi.randomClientId,
             _client_type = 2,
-            _client_version = clientVersionValue,
+            _client_version = clientVersion.version,
             _os_version = "${Build.VERSION.SDK_INT}",
             _phone_imei = MobileInfoUtil.getIMEI(context),
             _timestamp = System.currentTimeMillis(),
@@ -106,7 +105,7 @@ fun buildCommonRequest(
             BDUSS = AccountUtil.getBduss(),
             _client_id = ClientUtils.clientId ?: RetrofitTiebaApi.randomClientId,
             _client_type = 2,
-            _client_version = clientVersionValue,
+            _client_version = clientVersion.version,
             _os_version = "${Build.VERSION.SDK_INT}",
             _phone_imei = MobileInfoUtil.getIMEI(context),
             _timestamp = System.currentTimeMillis(),
@@ -145,7 +144,56 @@ fun buildCommonRequest(
             start_type = 1,
             stoken = AccountUtil.getSToken(),
             swan_game_ver = "1038000",
-            user_agent = getUserAgent("tieba/$clientVersionValue"),
+            user_agent = getUserAgent("tieba/${clientVersion.version}"),
+            z_id = AccountUtil.getAccountInfo { zid }
+        )
+    }
+
+    ClientVersion.TIEBA_V22 -> {
+        CommonRequest(
+            BDUSS = AccountUtil.getBduss(),
+            _client_id = ClientUtils.clientId ?: RetrofitTiebaApi.randomClientId,
+            _client_type = 2,
+            _client_version = clientVersion.version,
+            _os_version = "${Build.VERSION.SDK_INT}",
+            _phone_imei = MobileInfoUtil.getIMEI(context),
+            _timestamp = System.currentTimeMillis(),
+            active_timestamp = ClientUtils.activeTimestamp,
+            android_id = base64Encode(UIDUtil.getAndroidId("000")),
+            brand = Build.BRAND,
+            c3_aid = UIDUtil.getAid(),
+            cmode = 1,
+            cuid = CuidUtils.getNewCuid(),
+            cuid_galaxy2 = CuidUtils.getNewCuid(),
+            cuid_gid = "",
+            event_day = SimpleDateFormat("yyyyMdd", Locale.getDefault()).format(
+                Date(
+                    System.currentTimeMillis()
+                )
+            ),
+            extra = "",
+            first_install_time = App.Config.appFirstInstallTime,
+            framework_ver = "4220001",
+            from = "1020031h",
+            is_teenager = 0,
+            last_update_time = App.Config.appLastUpdateTime,
+            lego_lib_version = "3.0.0",
+            model = Build.MODEL,
+            net_type = 1,
+            oaid = "",
+            personalized_rec_switch = 1,
+            pversion = "1.0.3",
+            q_type = 0,
+            sample_id = ClientUtils.sampleId,
+            scr_dip = App.ScreenInfo.DENSITY.toDouble(),
+            scr_h = getScreenHeight(),
+            scr_w = getScreenWidth(),
+            sdk_ver = "3.36.0",
+            start_scheme = "",
+            start_type = 1,
+            stoken = AccountUtil.getSToken(),
+            swan_game_ver = "2035000",
+            user_agent = getUserAgent("tieba/${clientVersion.version}"),
             z_id = AccountUtil.getAccountInfo { zid }
         )
     }
@@ -155,7 +203,7 @@ fun buildCommonRequest(
             BDUSS = AccountUtil.getBduss(),
             _client_id = ClientUtils.clientId ?: RetrofitTiebaApi.randomClientId,
             _client_type = 2,
-            _client_version = clientVersionValue,
+            _client_version = clientVersion.version,
             _os_version = "${Build.VERSION.SDK_INT}", // TODO
             _phone_imei = MobileInfoUtil.getIMEI(context),
             _timestamp = System.currentTimeMillis(),
@@ -197,7 +245,7 @@ fun buildCommonRequest(
             stoken = AccountUtil.getSToken(),
             swan_game_ver = "1038000",
             tbs = tbs,
-            user_agent = getUserAgent("tieba/$clientVersionValue"),
+            user_agent = getUserAgent("tieba/${clientVersion.version}"),
             z_id = AccountUtil.getAccountInfo { zid }
         )
     }

--- a/app/src/main/java/com/huanchengfly/tieba/post/api/interfaces/impls/MixedTiebaApiImpl.kt
+++ b/app/src/main/java/com/huanchengfly/tieba/post/api/interfaces/impls/MixedTiebaApiImpl.kt
@@ -15,7 +15,6 @@ import com.huanchengfly.tieba.post.api.buildCommonRequest
 import com.huanchengfly.tieba.post.api.buildProtobufRequestBody
 import com.huanchengfly.tieba.post.api.getScreenHeight
 import com.huanchengfly.tieba.post.api.getScreenWidth
-import com.huanchengfly.tieba.post.api.getUserAgent
 import com.huanchengfly.tieba.post.api.interfaces.ITiebaApi
 import com.huanchengfly.tieba.post.api.models.AddThreadBean
 import com.huanchengfly.tieba.post.api.models.AgreeBean
@@ -153,7 +152,6 @@ import java.io.IOException
 import java.net.URLEncoder
 
 object MixedTiebaApiImpl : ITiebaApi {
-    private const val PB_FLOOR_CLIENT_VERSION = "22.10.1.0"
 
     override fun personalized(loadType: Int, page: Int): Call<PersonalizedBean> =
         RetrofitTiebaApi.MINI_TIEBA_API.personalized(loadType, page)
@@ -1419,14 +1417,11 @@ object MixedTiebaApiImpl : ITiebaApi {
         page: Int,
         subPostId: Long
     ): Flow<PbFloorResponse> {
-        return RetrofitTiebaApi.OFFICIAL_PROTOBUF_TIEBA_V12_API.pbFloorFlow(
-            body = buildProtobufRequestBody(
+        return RetrofitTiebaApi.OFFICIAL_PROTOBUF_TIEBA_V22_API.pbFloorFlow(
+            buildProtobufRequestBody(
                 PbFloorRequest(
                     PbFloorRequestData(
-                        common = buildCommonRequest(
-                            clientVersion = ClientVersion.TIEBA_V12,
-                            clientVersionValue = PB_FLOOR_CLIENT_VERSION,
-                        ),
+                        common = buildCommonRequest(clientVersion = ClientVersion.TIEBA_V22),
                         forum_id = forumId,
                         kz = threadId,
                         pid = postId,
@@ -1439,10 +1434,9 @@ object MixedTiebaApiImpl : ITiebaApi {
                         ori_ugc_type = 0
                     )
                 ),
-                clientVersion = ClientVersion.TIEBA_V12,
+                clientVersion = ClientVersion.TIEBA_V22,
                 needSToken = false
-            ),
-            userAgent = getUserAgent("tieba/$PB_FLOOR_CLIENT_VERSION"),
+            )
         )
     }
 

--- a/app/src/main/java/com/huanchengfly/tieba/post/api/interfaces/impls/MixedTiebaApiImpl.kt
+++ b/app/src/main/java/com/huanchengfly/tieba/post/api/interfaces/impls/MixedTiebaApiImpl.kt
@@ -15,6 +15,7 @@ import com.huanchengfly.tieba.post.api.buildCommonRequest
 import com.huanchengfly.tieba.post.api.buildProtobufRequestBody
 import com.huanchengfly.tieba.post.api.getScreenHeight
 import com.huanchengfly.tieba.post.api.getScreenWidth
+import com.huanchengfly.tieba.post.api.getUserAgent
 import com.huanchengfly.tieba.post.api.interfaces.ITiebaApi
 import com.huanchengfly.tieba.post.api.models.AddThreadBean
 import com.huanchengfly.tieba.post.api.models.AgreeBean
@@ -152,6 +153,8 @@ import java.io.IOException
 import java.net.URLEncoder
 
 object MixedTiebaApiImpl : ITiebaApi {
+    private const val PB_FLOOR_CLIENT_VERSION = "22.10.1.0"
+
     override fun personalized(loadType: Int, page: Int): Call<PersonalizedBean> =
         RetrofitTiebaApi.MINI_TIEBA_API.personalized(loadType, page)
 
@@ -1417,10 +1420,13 @@ object MixedTiebaApiImpl : ITiebaApi {
         subPostId: Long
     ): Flow<PbFloorResponse> {
         return RetrofitTiebaApi.OFFICIAL_PROTOBUF_TIEBA_V12_API.pbFloorFlow(
-            buildProtobufRequestBody(
+            body = buildProtobufRequestBody(
                 PbFloorRequest(
                     PbFloorRequestData(
-                        common = buildCommonRequest(clientVersion = ClientVersion.TIEBA_V12),
+                        common = buildCommonRequest(
+                            clientVersion = ClientVersion.TIEBA_V12,
+                            clientVersionValue = PB_FLOOR_CLIENT_VERSION,
+                        ),
                         forum_id = forumId,
                         kz = threadId,
                         pid = postId,
@@ -1435,7 +1441,8 @@ object MixedTiebaApiImpl : ITiebaApi {
                 ),
                 clientVersion = ClientVersion.TIEBA_V12,
                 needSToken = false
-            )
+            ),
+            userAgent = getUserAgent("tieba/$PB_FLOOR_CLIENT_VERSION"),
         )
     }
 

--- a/app/src/main/java/com/huanchengfly/tieba/post/api/retrofit/RetrofitTiebaApi.kt
+++ b/app/src/main/java/com/huanchengfly/tieba/post/api/retrofit/RetrofitTiebaApi.kt
@@ -161,7 +161,7 @@ object RetrofitTiebaApi {
                 Header.USER_AGENT to { "bdtb for Android 7.2.0.0" },
                 Header.CUID to { UIDUtil.finalCUID },
                 Header.CUID_GALAXY2 to { UIDUtil.finalCUID },
-                "client_logid" to { "$initTime" }
+                Header.CLIENT_LOG_ID to { "$initTime" }
             ),
             defaultCommonParamInterceptor + CommonParamInterceptor(
                 Param.CUID to { UIDUtil.finalCUID },
@@ -186,7 +186,7 @@ object RetrofitTiebaApi {
                 Header.CUID_GALAXY3 to { UIDUtil.getAid() },
                 Header.CLIENT_TYPE to { "2" },
                 Header.CHARSET to { "UTF-8" },
-                "client_logid" to { "$initTime" }
+                Header.CLIENT_LOG_ID to { "$initTime" }
             ),
             defaultCommonParamInterceptor + CommonParamInterceptor(
                 Param.ACTIVE_TIMESTAMP to { ClientUtils.activeTimestamp.toString() },
@@ -258,6 +258,7 @@ object RetrofitTiebaApi {
             CommonHeaderInterceptor(
                 Header.CHARSET to { "UTF-8" },
                 Header.CLIENT_TYPE to { "2" },
+                Header.CLIENT_LOG_ID to { "$initTime" },
                 Header.CLIENT_USER_TOKEN to { AccountUtil.getUid() },
                 Header.COOKIE to {
                     getCookie(
@@ -271,6 +272,31 @@ object RetrofitTiebaApi {
                 Header.CUID_GID to { "" },
                 Header.CUID_GALAXY3 to { UIDUtil.getAid() },
                 Header.USER_AGENT to { getUserAgent("tieba/${ClientVersion.TIEBA_V12.version}") },
+                Header.X_BD_DATA_TYPE to { "protobuf" },
+            ),
+            stParamInterceptor,
+        )
+    }
+
+    val OFFICIAL_PROTOBUF_TIEBA_V22_API: OfficialProtobufTiebaApi by lazy {
+        createProtobufApi<OfficialProtobufTiebaApi>(
+            "https://tiebac.baidu.com/",
+            CommonHeaderInterceptor(
+                Header.CHARSET to { "UTF-8" },
+                Header.CLIENT_TYPE to { "2" },
+                Header.CLIENT_USER_TOKEN to { AccountUtil.getUid() },
+                Header.COOKIE to {
+                    getCookie(
+                        "ka" to { "open" },
+                        "CUID" to { CuidUtils.getNewCuid() },
+                        "TBBRAND" to { Build.MODEL }
+                    )
+                },
+                Header.CUID to { CuidUtils.getNewCuid() },
+                Header.CUID_GALAXY2 to { CuidUtils.getNewCuid() },
+                Header.CUID_GID to { "" },
+                Header.CUID_GALAXY3 to { UIDUtil.getAid() },
+                Header.USER_AGENT to { getUserAgent("tieba/${ClientVersion.TIEBA_V22.version}") },
                 Header.X_BD_DATA_TYPE to { "protobuf" },
             ),
             stParamInterceptor,

--- a/app/src/main/java/com/huanchengfly/tieba/post/api/retrofit/interfaces/OfficialProtobufTiebaApi.kt
+++ b/app/src/main/java/com/huanchengfly/tieba/post/api/retrofit/interfaces/OfficialProtobufTiebaApi.kt
@@ -84,7 +84,6 @@ interface OfficialProtobufTiebaApi {
     @POST("/c/f/pb/floor?cmd=302002&format=protobuf")
     fun pbFloorFlow(
         @Body body: MyMultipartBody,
-        @Header("User-Agent") userAgent: String? = null,
     ): Flow<PbFloorResponse>
 
     @POST("/c/c/post/add?cmd=309731&format=protobuf")

--- a/app/src/main/java/com/huanchengfly/tieba/post/api/retrofit/interfaces/OfficialProtobufTiebaApi.kt
+++ b/app/src/main/java/com/huanchengfly/tieba/post/api/retrofit/interfaces/OfficialProtobufTiebaApi.kt
@@ -84,6 +84,7 @@ interface OfficialProtobufTiebaApi {
     @POST("/c/f/pb/floor?cmd=302002&format=protobuf")
     fun pbFloorFlow(
         @Body body: MyMultipartBody,
+        @Header("User-Agent") userAgent: String? = null,
     ): Flow<PbFloorResponse>
 
     @POST("/c/c/post/add?cmd=309731&format=protobuf")


### PR DESCRIPTION
 ## 背景

  官方贴吧客户端新增了在楼中楼回复中发送图片的功能，TiebaLite 同步适配该内容形式。

  现有楼中楼接口请求使用 `12.52.1.0` 客户端版本标识，服务端不会返回新增的楼中楼图片数据。项目现有的 protobuf 内容解析和图片渲染流程已经支持图片，因此本次改动主要用于获取完整的接口响应。

  ## 变更内容

  - 为 `buildCommonRequest` 增加可选的客户端版本值参数
  - 为 `pb/floor` 请求单独使用 `22.10.1.0` 客户端版本标识
  - 同步更新请求体中的 `_client_version` 和内嵌 `user_agent`
  - 支持为 `pbFloorFlow` 单独设置 HTTP `User-Agent`
  - 复用现有图片内容解析与渲染流程展示楼中楼图片

  ## 影响范围

  客户端版本覆盖仅应用于 `pb/floor` 接口，其他 V12 protobuf 接口继续使用默认版本。

  ## 验证

  - [x] `git diff --check`
  - [x] `./gradlew :app:compileDebugKotlin --no-daemon`
  - [x] 验证官方客户端发送的楼中楼图片
  
   ## 关联 Issue

  Closes #117